### PR TITLE
Fix $SNAP_ARCH parsing on arm64

### DIFF
--- a/snap/scripts/launcher
+++ b/snap/scripts/launcher
@@ -3,7 +3,7 @@ case "$SNAP_ARCH" in
     *86)
     ARCH="i386-linux-gnu"
     ;;
-    *64)
+    amd64)
     ARCH="x86_64-linux-gnu"
     ;;
     *)


### PR DESCRIPTION
This stops treating any `$SNAP_ARCH` value ending in 64 (such as arm64) as x86_64.