### PR TITLE
Switch to Minetest's Irrlicht fork

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,11 +40,19 @@ parts:
       if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
         git fetch
         git checkout "${last_committed_tag}"
-      fi 
+      fi
     override-build: |
       snapcraftctl build
     organize:
       '*': 'share/minetest/games/minetest_game/'
+  irrlicht:
+    source: https://github.com/minetest/irrlicht.git
+    source-branch: master
+    plugin: cmake
+    override-pull: |
+      snapcraftctl pull
+      tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+      git checkout "$tag"
   minetest:
     source: https://github.com/minetest/minetest.git
     override-pull: |
@@ -65,19 +73,18 @@ parts:
       snapcraftctl build
     plugin: cmake
     configflags: ["-DRUN_IN_PLACE=FALSE", "-DCMAKE_BUILD_TYPE=Release"]
+    after:
+      - irrlicht
     build-packages:
       - cmake
       - gcc
       - g++
       - gettext
-      - imagemagick
-      - libbz2-dev
       - libcurl4-gnutls-dev
       - libfreetype6-dev
       - libglu1-mesa-dev
       - libirrlicht-dev
       - libjpeg-dev
-      - libjsoncpp-dev
       - libleveldb-dev
       - libluajit-5.1-dev
       - libogg-dev
@@ -112,5 +119,4 @@ parts:
       - libx11-6
       - libx11-xcb1
       - libfreetype6
-      - libirrlicht1.8
       - libpng16-16

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -126,3 +126,4 @@ parts:
       - libx11-xcb1
       - libfreetype6
       - libpng16-16
+      - libzstd1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,8 +83,9 @@ parts:
       - libcurl4-gnutls-dev
       - libfreetype6-dev
       - libglu1-mesa-dev
-      - libirrlicht-dev
+      - libgmp-dev
       - libjpeg-dev
+      - libjsoncpp-dev
       - libleveldb-dev
       - libluajit-5.1-dev
       - libogg-dev
@@ -93,13 +94,17 @@ parts:
       - libpulse-dev
       - libsqlite3-dev
       - libvorbis-dev
+      - libxi-dev
       - libx11-dev
+      - libzstd-dev
       - zlib1g-dev
     stage-packages:
       - libgl1-mesa-dri
       - libpulse0
       - libcurl3-gnutls
       - libgl1-mesa-glx
+      - libgmp10
+      - libjsoncpp25
       - libxshmfence1
       - libxcb-sync1
       - libxcb-present0
@@ -116,6 +121,7 @@ parts:
       - libxfixes3
       - libxext6
       - libxdamage1
+      - libxi6
       - libx11-6
       - libx11-xcb1
       - libfreetype6


### PR DESCRIPTION
This is required to build Minetest since https://github.com/minetest/minetest/commit/91c9313c87bfec8b44e5adb91b06aba9f343dd53.

I have also removed `imagemagick` and `libjsoncpp-dev` from build-packages because Minetest doesn't seem to need them (while Minetest can use the system libjsoncpp, it has been defaulting to the bundled one until 5.5.0-dev anyway).

*While I have tested the irrlicht fork at https://github.com/luk3yx/minetest-luk3yx-dev/commit/58aa1d717de2298877a0778a2a2ba820953d3b08, I haven't tested this PR.*