### PR TITLE
Switching pulseaudio plug to audio-playback

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ apps:
     environment:
       HOME: "$SNAP_USER_COMMON"
     command: launcher
-    plugs: [desktop, desktop-legacy, x11, network, network-bind, opengl, pulseaudio, home, removable-media]
+    plugs: [desktop, desktop-legacy, x11, network, network-bind, opengl, audio-playback, home, removable-media]
 
 parts:
   launcher:


### PR DESCRIPTION
The pulseaudio plug will allow the app to both play and record audio, and there's not really a reason for it to record any audio. The audio-playback plug will only allow audio output and block all audio input, which is a safer permission to grant the app.