### PR TITLE
Update luanti to 5.14

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: luanti
-version: 5.13.0
+version: 5.14.0
 
 summary: Open source voxel game engine (formerly minetest)
 description: |


### PR DESCRIPTION
Released Oct 5: https://blog.luanti.org/2025/10/05/5.14.0-released/

Built & tested locally in devmode; works with Mineclonia.