### PR TITLE
Update luanti to 5.15

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: luanti
-version: 5.15.0
+version: 5.15.1
 
 summary: Open source voxel game engine (formerly minetest)
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: luanti
-version: 5.14.0
+version: 5.15.0
 
 summary: Open source voxel game engine (formerly minetest)
 description: |


### PR DESCRIPTION
Released Jan 26:  https://blog.luanti.org/2026/01/24/5.15.0-released/

Built & tested locally with `--devmode`.

It works with Mineclonia without visible issues.