### PR TITLE
Update luanti to 5.15.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: luanti
-version: 5.15.1
+version: 5.15.2
 
 summary: Open source voxel game engine (formerly minetest)
 description: |


### PR DESCRIPTION
Released Apr 14: 
https://github.com/luanti-org/luanti/releases/tag/5.15.2
https://docs.luanti.org/about/changelog/#5151--5152

> [!WARNING]  
> **This release fixes critical security vulnerabilities affecting both the client and server.**

Built & tested locally with `--devmode`.

It works with Mineclonia without visible issues.


Relates to #58